### PR TITLE
Add SuffolkLITLab/ALActions workflows

### DIFF
--- a/.github/workflows/da_build.yml
+++ b/.github/workflows/da_build.yml
@@ -1,0 +1,12 @@
+name: DA Build
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: SuffolkLITLab/ALActions/da_build@main

--- a/.github/workflows/valid_jinja2.yml
+++ b/.github/workflows/valid_jinja2.yml
@@ -1,0 +1,11 @@
+name: Valid Jinja2
+on:
+  push:
+    branches:
+      - "**"
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: SuffolkLITLab/ALActions/valid_jinja2@main

--- a/.github/workflows/word_diff.yml
+++ b/.github/workflows/word_diff.yml
@@ -1,0 +1,9 @@
+name: Word Diff
+on:
+  pull_request:
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: SuffolkLITLab/ALActions/word_diff@main


### PR DESCRIPTION

This pull request adds one or more GitHub Actions workflows from
the SuffolkLITLab/ALActions repository:

- `da_build` for all docassemble repos
- `valid_jinja2` and `word_diff` for repos with .docx files

These workflows standardize testing, validation, and Word diff checks across docassemble packages.
